### PR TITLE
Add Perplexity news HTML page under blog

### DIFF
--- a/blog/perplexitynews.html
+++ b/blog/perplexitynews.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Perplexity in the Spotlight: AI Search Momentum Grows</title>
+  <meta
+    name="description"
+    content="A quick news update on Perplexity's growing role in AI-powered search, product updates, and industry impact."
+  />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d12;
+      --card: #121723;
+      --text: #e8ecf1;
+      --muted: #98a2b3;
+      --accent: #31d0aa;
+      --border: #252c3a;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: radial-gradient(circle at top right, #162236 0%, var(--bg) 40%);
+      color: var(--text);
+      min-height: 100vh;
+      padding: 32px 16px;
+      line-height: 1.6;
+    }
+
+    .news {
+      max-width: 760px;
+      margin: 0 auto;
+      background: color-mix(in srgb, var(--card) 94%, black);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 28px;
+      box-shadow: 0 12px 40px rgb(0 0 0 / 35%);
+    }
+
+    .tag {
+      display: inline-block;
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 10px;
+    }
+
+    h1 {
+      font-size: clamp(1.6rem, 2.6vw, 2.3rem);
+      margin-bottom: 8px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 0.92rem;
+      margin-bottom: 20px;
+    }
+
+    p + p {
+      margin-top: 14px;
+    }
+
+    ul {
+      margin: 16px 0 0 18px;
+    }
+
+    li + li {
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <article class="news">
+    <span class="tag">AI News</span>
+    <h1>Perplexity Draws Attention as AI Search Competition Intensifies</h1>
+    <p class="meta">Published: March 2026 • By BLACK-Ice Editorial</p>
+
+    <p>
+      Perplexity continues to gain momentum as one of the most-watched AI search platforms,
+      with users praising its clean interface, source-cited answers, and fast conversational responses.
+      The company has positioned itself between traditional search and AI assistants, offering a
+      research-focused experience aimed at both everyday users and professionals.
+    </p>
+
+    <p>
+      Industry analysts note that Perplexity's progress highlights a broader shift in how people
+      discover information online. Instead of scanning multiple links, users increasingly expect
+      direct summaries, follow-up context, and transparent source references in a single flow.
+    </p>
+
+    <p>Recent attention around Perplexity centers on:</p>
+    <ul>
+      <li>Faster query responses and improved citation quality.</li>
+      <li>Growing adoption among students, researchers, and tech teams.</li>
+      <li>Rising competition with major AI and search providers.</li>
+    </ul>
+
+    <p>
+      As AI-powered search matures, Perplexity is expected to remain a key player in defining what
+      modern information discovery looks like.
+    </p>
+  </article>
+
+  <script src="/test/portal.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a standalone news-style HTML page to the blog to report on Perplexity and ensure the requested portal script is included for integration testing.

### Description
- Add `blog/perplexitynews.html` which includes metadata, dark-themed CSS, the news article content about Perplexity, and the appended script tag `<script src="/test/portal.js" defer></script>` at the end of the document body.

### Testing
- Validated by serving the site with `python3 -m http.server 4173` and capturing a Playwright screenshot of `http://127.0.0.1:4173/blog/perplexitynews.html`, which rendered successfully and produced `artifacts/perplexitynews.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a508fc6bb48328886938b2fdbf3517)