### PR TITLE
Add standalone HTML PDF viewer page

### DIFF
--- a/pdfviewer.html
+++ b/pdfviewer.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PDF Viewer</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f3f4f6;
+      --card: #ffffff;
+      --accent: #2563eb;
+      --text: #111827;
+      --muted: #6b7280;
+      --border: #d1d5db;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 16px;
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      display: grid;
+      gap: 12px;
+    }
+
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    input[type="url"],
+    input[type="file"],
+    input[type="number"] {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 12px;
+      font-size: 14px;
+      background: #fff;
+    }
+
+    input[type="url"] {
+      flex: 1 1 320px;
+      min-width: 220px;
+    }
+
+    button {
+      border: none;
+      border-radius: 8px;
+      background: var(--accent);
+      color: #fff;
+      padding: 10px 14px;
+      cursor: pointer;
+      font-weight: 600;
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .meta {
+      display: flex;
+      gap: 16px;
+      color: var(--muted);
+      font-size: 14px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    main {
+      flex: 1;
+      padding: 12px;
+      display: flex;
+    }
+
+    #viewer {
+      width: 100%;
+      height: calc(100vh - 210px);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: #fff;
+    }
+
+    .hint {
+      color: var(--muted);
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1 style="margin:0;font-size:1.25rem;">PDF Viewer</h1>
+    <div class="controls">
+      <input id="urlInput" type="url" placeholder="Paste a direct PDF URL (https://...)" />
+      <button id="loadUrlBtn" type="button">Load URL</button>
+      <input id="fileInput" type="file" accept="application/pdf" />
+      <label>
+        Zoom (%)
+        <input id="zoomInput" type="number" min="25" max="300" step="5" value="100" style="width:90px" />
+      </label>
+    </div>
+    <div class="meta">
+      <span id="statusText">No PDF loaded.</span>
+      <span class="hint">Tip: remote URLs must allow embedding/CORS or they may not load.</span>
+    </div>
+  </header>
+
+  <main>
+    <embed id="viewer" type="application/pdf" />
+  </main>
+
+  <script>
+    const urlInput = document.getElementById('urlInput');
+    const fileInput = document.getElementById('fileInput');
+    const loadUrlBtn = document.getElementById('loadUrlBtn');
+    const zoomInput = document.getElementById('zoomInput');
+    const viewer = document.getElementById('viewer');
+    const statusText = document.getElementById('statusText');
+
+    let currentSource = '';
+
+    function setStatus(message) {
+      statusText.textContent = message;
+    }
+
+    function applyZoom() {
+      const value = Number(zoomInput.value);
+      const zoom = Number.isFinite(value) ? Math.min(300, Math.max(25, value)) : 100;
+      zoomInput.value = zoom;
+      if (!currentSource) return;
+      loadPdf(currentSource, zoom);
+    }
+
+    function loadPdf(src, zoom = Number(zoomInput.value) || 100) {
+      currentSource = src;
+      const separator = src.includes('#') ? '&' : '#';
+      viewer.src = `${src}${separator}zoom=${zoom}`;
+      setStatus(`Loaded PDF at ${zoom}% zoom.`);
+    }
+
+    loadUrlBtn.addEventListener('click', () => {
+      const raw = urlInput.value.trim();
+      if (!raw) {
+        setStatus('Enter a PDF URL first.');
+        return;
+      }
+      loadPdf(raw);
+    });
+
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files?.[0];
+      if (!file) return;
+      if (file.type !== 'application/pdf') {
+        setStatus('Please choose a valid PDF file.');
+        return;
+      }
+      const localUrl = URL.createObjectURL(file);
+      setStatus(`Loaded local file: ${file.name}`);
+      loadPdf(localUrl);
+    });
+
+    zoomInput.addEventListener('change', applyZoom);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a lightweight, standalone in-browser PDF viewer to quickly preview PDFs from a remote URL or a local file without extra dependencies.
- Expose a simple zoom control and inline status messages so users can adjust view scale and see basic feedback.
- Ship a self-contained HTML page that can be dropped into the site or used for local previews.

### Description
- Added a new file `pdfviewer.html` that implements a minimal UI with a URL input, a local file input, a zoom numeric input (25–300%), and a status line.
- Renders PDFs using an `<embed>` element and applies zoom via PDF fragment parameters (appends `#zoom=`), and uses `URL.createObjectURL` for local files.
- Performs client-side MIME validation for uploaded files (`application/pdf`) and clamps zoom values to the 25–300% range.
- Includes responsive CSS and lightweight JavaScript to manage loading, zoom application, and user-facing messages.

### Testing
- Launched a local static server with `python3 -m http.server 4173 --directory /workspace/BLACK-Ice` to preview the page, which started successfully.
- Attempted an automated Playwright run to open `http://127.0.0.1:4173/pdfviewer.html` and capture a screenshot, but the Chromium browser process crashed with a SIGSEGV so screenshot capture failed.
- Inspected the generated `pdfviewer.html` content locally (printed with line numbers) to verify the file was created and contains the expected UI and script, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a511499c8c8328ae5739f1955e7c21)